### PR TITLE
fix:broken-login-height

### DIFF
--- a/treetory/app/(header)/(menu)/layout.tsx
+++ b/treetory/app/(header)/(menu)/layout.tsx
@@ -1,6 +1,6 @@
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="relative flex h-full flex-col overflow-auto">
+    <div className="relative flex h-full w-full flex-col overflow-auto">
       {children}
     </div>
   );

--- a/treetory/app/globals.css
+++ b/treetory/app/globals.css
@@ -133,7 +133,7 @@ body > .app-container {
 @media (min-width: 376px) {
   body > .app-container {
     width: 100vw;
-    max-width: 720px;
+    max-width: 640px;
     height: 100vh;
     border-radius: 20px;
     padding-top: 48px;

--- a/treetory/app/login/login.module.css
+++ b/treetory/app/login/login.module.css
@@ -1,3 +1,34 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+  gap: 8px;
+}
+
+.loginHeadingWrapper {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.loginWrapper {
+  height: 80dvh;
+  min-height: 720px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.loginButtonWrapper {
+  display: flex;
+  align-items: start;
+  justify-content: center;
+  padding-top: 20px;
+  gap: 0px;
+}
+
 .loginButton {
   position: relative;
   cursor: pointer;
@@ -6,6 +37,73 @@
   align-items: center;
   border-radius: 100%;
   padding: 4px;
+  width: 80px;
+  height: 80px;
+}
+
+@media (min-height: 915px) {
+  .container {
+    gap: 72px;
+  }
+  .loginHeadingWrapper {
+    padding-top: 48px;
+  }
+  .loginWrapper {
+    max-height: 900px;
+  }
+
+  .loginButtonWrapper {
+    padding-top: 40px;
+    gap: 16px;
+  }
+
+  .loginButton {
+    width: 108px;
+    height: 108px;
+  }
+}
+
+@media (min-height: 731px) and (max-height: 914px) {
+  .container {
+    gap: 44px;
+  }
+
+  .loginWrapper {
+    max-height: 900px;
+  }
+
+  .loginHeadingWrapper {
+    padding-top: 48px;
+  }
+
+  .loginButtonWrapper {
+    display: flex;
+    align-items: start;
+    justify-content: center;
+    padding-top: 28px;
+    gap: 8px;
+  }
+
+  .loginButton {
+    width: 88px;
+    height: 88px;
+  }
+}
+
+/* 너무 작을 때 최소 720 보장 */
+@media (max-height: 730px) {
+  .container {
+    gap: 40px;
+  }
+
+  .loginWrapper {
+    height: 80dvh;
+    min-height: 720px;
+  }
+
+  .loginHeadingWrapper {
+    padding-top: 32px;
+  }
 }
 
 .tooltip {

--- a/treetory/app/login/page.tsx
+++ b/treetory/app/login/page.tsx
@@ -8,22 +8,22 @@ import style from "@/app/login/login.module.css";
 
 export default function Page() {
   return (
-    <div className="flex flex-col justify-end gap-20">
-      <div className="p flex w-full flex-col items-center gap-2 pt-20">
-        <h1 className="font-memoment text-green text-8xl">트리토리</h1>
-        <p className="text-body text-beige font-light">
+    <div className={`${style.container}`}>
+      <div className={`${style.loginHeadingWrapper} `}>
+        <h1 className="font-memoment text-green text-7xl md:text-8xl">
+          트리토리
+        </h1>
+        <p className="text-body text-beige text-base font-light">
           함께 완성하는 우리만의 크리스마스 이야기
         </p>
       </div>
       <div
-        className="flex h-[80dvh] min-h-[540px] flex-col items-center justify-center bg-cover bg-center md:h-[85dvh]"
+        className={`bg-cover bg-center ${style.loginWrapper}`}
         style={{ backgroundImage: `url('/images/tree_login.png')` }}
       >
-        <div className="flex w-full items-start justify-center gap-1 pt-14 md:gap-4">
+        <div className={`${style.loginButtonWrapper} w-full`}>
           <div className="flex w-34 flex-col items-center md:w-40">
-            <button
-              className={`size-20 md:size-24 ${style.loginButton} bg-white`}
-            >
+            <button className={`${style.loginButton} bg-white`}>
               <Image
                 src={BellRing1}
                 alt="로고 장식1"
@@ -33,9 +33,7 @@ export default function Page() {
             </button>
           </div>
           <div className="flex w-34 flex-col items-center md:w-40">
-            <button
-              className={`size-20 bg-[#FFEC00] md:size-24 ${style.loginButton}`}
-            >
+            <button className={`bg-[#FFEC00] ${style.loginButton}`}>
               <Image
                 src={BellRing2}
                 alt="로고 장식2"


### PR DESCRIPTION
## 🛠 작업 사항(required)
- global css + Login css 반응형 CSS 수정

## 💗 관심 리뷰(optional)
- 뷰포트를 기존에 mobile/pc 기준으로 반응형 구현한 부분이 height가 pc 기준 보다 작을 때 깨짐 현상 발생
- 노트북 기준 제일 작은 뷰포트 높이 712를 기준으로 수정하여 테스트 완료 
- 로그인 화면에 반응형으로 구현해야 하는 모든 UI를 위와 같은 기준으로 수정
- 각 대표 디바이스 (galaxy ultra 20, iphone 12pro 이상 테스트 완료, 태블릿 테스트 완료)

## 👀 실행 화면(optional) 
- 이전 화면
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/4e82d713-32e0-4e08-bfdb-a24371ed29ca" />

- 수정 화면
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/77535861-3161-4f43-9dc9-8ff0b024401b" />
