### PR TITLE
fix:zustand setState 설정 변경 & user response key 반영

### DIFF
--- a/treetory/app/(header)/(menu)/settings/page.tsx
+++ b/treetory/app/(header)/(menu)/settings/page.tsx
@@ -4,15 +4,17 @@ import PageHeading from "@/components/commons/PageHeading";
 import ContentSection from "@/components/commons/ContentSection";
 import ContentContainer from "@/components/ui/settings/ContentContainer";
 import { MoveRight, SquarePen, MessageCircleQuestionMark } from "lucide-react";
+
 import { useRouter } from "next/navigation";
 import { useUserStore } from "@/store/useStore";
+
 import { useBottomSheet } from "@/hooks/useBottomSheet";
-import { BottomSheet } from "@/components/commons/BottomSheet";
 import NicknameBottomSheet from "@/components/ui/settings/nicknameBottomSheet";
 
 export default function Page() {
   const router = useRouter();
   const user = useUserStore((s) => s.user);
+  console.log("user: ", user);
 
   // 닉네임 바텀 시트 상태 관리
   const { isOpen, open, close } = useBottomSheet();
@@ -27,7 +29,7 @@ export default function Page() {
             <p className="text-caption md:text-body text-muted-navy">닉네임</p>
             {/* 닉네임 정보 */}
             <div className="text-body bg-muted-bg text-navy rounded-lg px-2 py-4 md:text-lg">
-              {user?.nickname ?? "닉네임"}
+              {user?.nickname}
             </div>
             <div className="flex justify-end">
               <button
@@ -42,7 +44,7 @@ export default function Page() {
             <p className="text-caption md:text-body text-muted-navy">
               가입 계정
             </p>
-            <p className="text-navy text-body md:text-lg">id@email.com</p>
+            <p className="text-navy text-body md:text-lg">{user?.email}</p>
           </div>
         </ContentContainer>
 
@@ -64,7 +66,7 @@ export default function Page() {
                 현재 적용된 배경
               </p>
               <p className="text-navy text-body text-primary md:text-lg">
-                고요한밤
+                {user?.background}
               </p>
             </div>
             <div className="py-1">
@@ -72,7 +74,7 @@ export default function Page() {
                 현재 적용된 트리
               </p>
               <p className="text-navy text-body text-primary md:text-lg">
-                눈 덮인 트리
+                {user?.theme}
               </p>
             </div>
           </div>

--- a/treetory/app/login/success/page.tsx
+++ b/treetory/app/login/success/page.tsx
@@ -7,8 +7,7 @@ import style from "@/app/login/login.module.css";
 
 export default function Page() {
   const router = useRouter();
-  const user = useUserStore();
-  const setUser = useUserStore((s) => s.setUser);
+  const setUser = useUserStore.getState().setUser;
 
   useEffect(() => {
     async function getUser() {
@@ -22,7 +21,7 @@ export default function Page() {
       const data = await res.json();
       setUser(data);
       //    임시로 tree/1로 이동
-      router.replace(`/tree/${data.memberId ?? "1"}`);
+      router.replace(`/tree/${data.uuid ?? "1"}`);
     }
 
     getUser();

--- a/treetory/components/ui/settings/nicknameBottomSheet.tsx
+++ b/treetory/components/ui/settings/nicknameBottomSheet.tsx
@@ -16,6 +16,8 @@ export default function NicknameBottomSheet({
   onClose,
 }: BottomSheetProps) {
   const user = useUserStore((s) => s.user);
+  const setUser = useUserStore.getState().setUser;
+
   const [nickname, setNickname] = useState("");
 
   useEffect(() => {
@@ -58,7 +60,9 @@ export default function NicknameBottomSheet({
     }
 
     const data = await res.json();
-    useUserStore((s) => s.setUser({ nickname: data.nickname }));
+    console.log("닉네임 변경 성공!");
+    setUser({ nickname: data.nickname });
+    console.log(user);
     onClose();
   };
 

--- a/treetory/types/user.ts
+++ b/treetory/types/user.ts
@@ -1,5 +1,5 @@
 export type User = {
-  memberId?: string; // 임시로 옵셔널 설정
+  uuid?: string;
   nickname?: string;
   email?: string;
   theme?: string;


### PR DESCRIPTION
## 🛠 작업 사항(required)
- 닉네임 변경 시 리액트 에러 321 번 발생 

`Error: Minified React error #321; visit https://react.dev/errors/321 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.`

- 사용자 정보 설정 화면에 반영되지 않음
- 설정에 표시되는 유저 정보 모두 표시
- 유저 타입 -> uuid 값 추가 

## 💗 관심 리뷰(optional)
- Zustand의 getState로 상태 업데이트 로직 변경 : 기존 (s->setUser()) 방식은 store 저장과 렌더링 방식이 꼬일 수 있음
- getState() 사용시 리다이렉트 보다 먼저 store에 저장되어 하이드레이션과 렌더링을 분리할 수 있음
- 배포 후 테스트 예정 